### PR TITLE
Use more generic event

### DIFF
--- a/app/code/community/Spranks/AutomaticInvoices/Model/Observer.php
+++ b/app/code/community/Spranks/AutomaticInvoices/Model/Observer.php
@@ -9,53 +9,47 @@ class Spranks_AutomaticInvoices_Model_Observer
      *
      * @param Varien_Event_Observer $observer
      */
-    public function checkoutSubmitAllAfter(Varien_Event_Observer $observer)
+    public function salesModelServiceQuoteSubmitAfter(Varien_Event_Observer $observer)
     {
         /** @var Spranks_AutomaticInvoices_Helper_Config $helper */
         $helper = Mage::helper('spranks_automaticinvoices/config');
         // if module is disabled, do nothing
-        if ( ! $helper->isActive()) {
+        if (!$helper->isActive()) {
             return;
         }
-        // get the order from the onepage checkout or the orderS from the multishipping checkout
-        $orders = $observer->getOrders();
-        if (empty($orders)) {
-            $orders = array($observer->getOrder());
-            if (empty($orders)) {
-                return;
-            }
+        $order = $observer->getOrder();
+        if (empty($order)) {
+            return;
         }
 
-        foreach ($orders as $order) {
-            /* @var $order Mage_Sales_Model_Order */
-            // if orders with this payment method should not be invoiced, do nothing
-            if ( ! $helper->shouldInvoiceOrder($order)) {
-                continue;
-            }
-            // if order can be invoiced / has not been invoiced yet, invoice it
-            if ($order->canInvoice()) {
-                $captureCase = $helper->getCaptureInvoice($order);
-                /* @var $invoice Mage_Sales_Model_Order_Invoice */
-                $invoice = $order->prepareInvoice();
-                $invoice->setRequestedCaptureCase($captureCase);
-                $invoice->register();
-                $invoice->getOrder()->setIsInProcess(true);
-                Mage::getModel('core/resource_transaction')
-                    ->addObject($invoice)
-                    ->addObject($invoice->getOrder())
-                    ->save();
-            } else {
-                // order has already been invoiced, so get the invoice
-                $invoice = $order->getInvoiceCollection()->getFirstItem();
-            }
-            // if invoice mail should not be sent, do nothing more
-            if ( ! $helper->shouldSendInvoiceEmail($order)) {
-                continue;
-            }
-            // if invoice has not been sent to the customer yet, send it now
-            if ($invoice && ! $invoice->getEmailSent()) {
-                $invoice->sendEmail();
-            }
+        /* @var $order Mage_Sales_Model_Order */
+        // if orders with this payment method should not be invoiced, do nothing
+        if (!$helper->shouldInvoiceOrder($order)) {
+            return;
+        }
+        // if order can be invoiced / has not been invoiced yet, invoice it
+        if ($order->canInvoice()) {
+            $captureCase = $helper->getCaptureInvoice($order);
+            /* @var $invoice Mage_Sales_Model_Order_Invoice */
+            $invoice = $order->prepareInvoice();
+            $invoice->setRequestedCaptureCase($captureCase);
+            $invoice->register();
+            $invoice->getOrder()->setIsInProcess(true);
+            Mage::getModel('core/resource_transaction')
+                ->addObject($invoice)
+                ->addObject($invoice->getOrder())
+                ->save();
+        } else {
+            // order has already been invoiced, so get the invoice
+            $invoice = $order->getInvoiceCollection()->getFirstItem();
+        }
+        // if invoice mail should not be sent, do nothing more
+        if (!$helper->shouldSendInvoiceEmail($order)) {
+            return;
+        }
+        // if invoice has not been sent to the customer yet, send it now
+        if ($invoice && !$invoice->getEmailSent()) {
+            $invoice->sendEmail();
         }
     }
 

--- a/app/code/community/Spranks/AutomaticInvoices/etc/config.xml
+++ b/app/code/community/Spranks/AutomaticInvoices/etc/config.xml
@@ -22,15 +22,15 @@
             </spranks_automaticinvoices>
         </models>
         <events>
-            <checkout_submit_all_after>
+            <sales_model_service_quote_submit_after>
                 <observers>
                     <spranks_automaticinvoices>
                         <type>model</type>
                         <class>spranks_automaticinvoices/observer</class>
-                        <method>checkoutSubmitAllAfter</method>
+                        <method>salesModelServiceQuoteSubmitAfter</method>
                     </spranks_automaticinvoices>
                 </observers>
-            </checkout_submit_all_after>
+            </sales_model_service_quote_submit_after>
         </events>
     </global>
     <adminhtml>


### PR DESCRIPTION
Using this event will also directly work for payment methods like PayPal, where the original event was not fired.